### PR TITLE
#120054 - Roll out CentOS 8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
   tags:
     - auditd
     - selinux
-  when: use_audisp
+  when: audisp_not_plugin
 
 - name: audispd syslog plugin Configuration
   template:
@@ -63,7 +63,6 @@
   tags:
     - auditd
     - selinux
-  when: use_audisp
 
 - name: Service enabled and started
   service:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,6 +1,7 @@
 ---
 auditd_packages:
   - audit
+  - audispd-plugins
 auditd_defaults:
   action_mail_acct: root
   admin_space_left: 50
@@ -32,4 +33,5 @@ auditd_defaults:
   tcp_max_per_addr: 1
   use_libwrap: True
 auditd_os_supported: yes
-use_audisp: no
+syslog_config_file: /etc/audit/plugins.d/syslog.conf
+audisp_not_plugin: no

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -45,4 +45,4 @@ syslog_defaults:
   path: builtin_syslog
   type: builtin
 auditd_os_supported: yes
-use_audisp: yes
+audisp_not_plugin: yes

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -45,4 +45,4 @@ syslog_defaults:
   path: builtin_syslog
   type: builtin 
 auditd_os_supported: yes
-use_audisp: yes
+audisp_not_plugin: yes


### PR DESCRIPTION
#120054 - Roll out CentOS 8
 - CentOS8 audit forwarding fixes (Audisp is a different plugin for which syslog still has to be configured)